### PR TITLE
docs: fix typo in `cacheAdapterEnhancer` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ new webpack.DefinePlugin({
 
 ## API
 
-### cacheAdapterEnhancer(adapter, { enable = true, cacheFlag = 'cache', defaultCache = new LRUCache({ maxAge: FIVE_MINUTES })) : enhancedAdapter
+### cacheAdapterEnhancer(adapter, { enabledByDefault = true, cacheFlag = 'cache', defaultCache = new LRUCache({ maxAge: FIVE_MINUTES })) : enhancedAdapter
 
 makes axios cacheable
 


### PR DESCRIPTION
You are using `enabledByDefault` in code but in docs it's `enable`. That's not correct