### PR TITLE
Add typescript module augmentation for cache.

### DIFF
--- a/src/cacheAdapterEnhancer.ts
+++ b/src/cacheAdapterEnhancer.ts
@@ -78,3 +78,9 @@ export default function cacheAdapterEnhancer(adapter: AxiosAdapter, options: Opt
 		return adapter(config);
 	};
 }
+
+declare module 'axios' {
+	interface AxiosRequestConfig {
+		cache?: boolean | true;
+	}
+}


### PR DESCRIPTION
Handle issue with
>Argument of type '{ cache: boolean; }' is not assignable to parameter of type 'AxiosRequestConfig'.