### PR TITLE
Add esm and lib folders to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage.lcov
 coverage/
 node_modules/
 dist/
+esm/
+lib/


### PR DESCRIPTION
## Reason

Folder esm and lib are left to project folder after running e.g. `npm run build`.
These folders do not belong to git repository so ignoring them.

 ### Change

Add esm and lib to ignored folders for git.