### PR TITLE
Expose utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,15 @@
 import Cache from 'lru-cache';
 import cacheAdapterEnhancer from './cacheAdapterEnhancer';
 import throttleAdapterEnhancer from './throttleAdapterEnhancer';
+import buildSortedURL from './utils/buildSortedURL';
+import isCacheLike from './utils/isCacheLike';
 
 export {
 	Cache,
 	cacheAdapterEnhancer,
 	throttleAdapterEnhancer,
+	utils: {
+		buildSortedURL,
+		isCacheLike,
+	},
 };


### PR DESCRIPTION
I would like to propose exposing these utils, so we can for example use `buildSortedUrl` to create identical cache keys and more efficiently manage the cache.