### PR TITLE
feat: add __fromCache indicator to cached responses

### DIFF
--- a/src/__tests__/test-cacheAdapterEnhancer.ts
+++ b/src/__tests__/test-cacheAdapterEnhancer.ts
@@ -214,6 +214,22 @@ describe('cacheAdapterEnhancer', () => {
 		expect(adapterCb.callCount).toBe(2);
 	});
 
+	it('cache adapter should mark cached responses with __fromCache only on cache hit', async () => {
+
+		const adapterCb = spy();
+		const mockedAdapter = genMockAdapter(adapterCb);
+		const http = axios.create({
+			adapter: cacheAdapterEnhancer(mockedAdapter),
+		});
+
+		const firstResponse = await http.get('/users');
+		expect(Reflect.get(firstResponse, '__fromCache')).toBeUndefined();
+
+		const secondResponse = await http.get('/users');
+		expect(Reflect.get(secondResponse, '__fromCache')).toBe(true);
+		expect(adapterCb.callCount).toBe(1);
+	});
+
 	it('cache adapter should support custom cache key generator', async () => {
 
 		const adapterCb = spy();

--- a/src/cacheAdapterEnhancer.ts
+++ b/src/cacheAdapterEnhancer.ts
@@ -17,6 +17,10 @@ declare module 'axios' {
 		forceUpdate?: boolean;
 		cache?: boolean | ICacheLike<any>;
 	}
+
+	interface AxiosResponse {
+		__fromCache?: boolean;
+	}
 }
 
 const FIVE_MINUTES = 1000 * 60 * 5;
@@ -78,7 +82,10 @@ export default function cacheAdapterEnhancer(adapter: NonNullable<AxiosRequestCo
 				console.info(`[axios-extensions] request cached by cache adapter --> url: ${index}`);
 			}
 
-			return responsePromise;
+			return responsePromise.then(response => ({
+				...response,
+				__fromCache: true,
+			}));
 		}
 
 		return resolvedAdapter(config);


### PR DESCRIPTION
## Summary

- Add `__fromCache` boolean flag to `AxiosResponse` when a response is served from cache, allowing users to distinguish cache hits from real network requests (closes #75, closes #87 closes #84)
- Extend `AxiosResponse` type via module augmentation with `__fromCache?: boolean`
- Add test covering both cache miss (no flag) and cache hit (`__fromCache === true`) scenarios

## Usage

```ts
const res = await http.get('/users');
if (res.__fromCache) {
  // Response came from cache — skip loading spinner, etc.
}
```

## Changes

- `src/cacheAdapterEnhancer.ts` — wrap cached promise to inject `__fromCache: true` on cache hit path
- `src/__tests__/test-cacheAdapterEnhancer.ts` — new test case