### PR TITLE
feat: support per-request threshold override in throttleAdapterEnhancer

### DIFF
--- a/src/__tests__/test-throttleAdapterEnhancer.ts
+++ b/src/__tests__/test-throttleAdapterEnhancer.ts
@@ -83,6 +83,42 @@ describe('throttleAdapterEnhancer', () => {
 		expect(adapterCb.callCount).toBe(2);
 	});
 
+	it('should use per-request threshold to override global threshold', async () => {
+
+		const adapterCb = spy();
+		const mockedAdapter = genMockAdapter(adapterCb);
+		const http = axios.create({
+			adapter: throttleAdapterEnhancer(mockedAdapter, { threshold: 1000 }),
+		});
+
+		await http.get('/users', { threshold: 100 });
+		await http.get('/users', { threshold: 100 });
+		expect(adapterCb.callCount).toBe(1);
+
+		await new Promise(r => setTimeout(r, 150));
+		await http.get('/users', { threshold: 100 });
+		expect(adapterCb.callCount).toBe(2);
+	});
+
+	it('should fallback to global threshold when per-request threshold is not set', async () => {
+
+		const globalThreshold = 200;
+		const adapterCb = spy();
+		const mockedAdapter = genMockAdapter(adapterCb);
+		const http = axios.create({
+			adapter: throttleAdapterEnhancer(mockedAdapter, { threshold: globalThreshold }),
+		});
+
+		await http.get('/users');
+		await new Promise(r => setTimeout(r, 100));
+		await http.get('/users');
+		expect(adapterCb.callCount).toBe(1);
+
+		await new Promise(r => setTimeout(r, globalThreshold));
+		await http.get('/users');
+		expect(adapterCb.callCount).toBe(2);
+	});
+
 	it('use a custom cache for throttle enhancer', async () => {
 
 		const adapterCb = spy();

--- a/src/throttleAdapterEnhancer.ts
+++ b/src/throttleAdapterEnhancer.ts
@@ -12,6 +12,12 @@ import { ICacheLike } from './utils/isCacheLike';
 import resolveAdapter from './utils/resolveAdapter';
 import shouldLogInfo from './utils/shouldLogInfo';
 
+declare module 'axios' {
+	interface AxiosRequestConfig {
+		threshold?: number;
+	}
+}
+
 export type RecordedCache = {
 	timestamp: number;
 	value?: AxiosPromise;
@@ -58,15 +64,16 @@ export default function throttleAdapterEnhancer(adapter: NonNullable<AxiosReques
 
 	return config => {
 
-		const { url, method, params, paramsSerializer } = config;
+		const { url, method, params, paramsSerializer, threshold: thresholdPerRequest } = config;
 		const index = buildSortedURL(url, params, paramsSerializer);
+		const effectiveThreshold = thresholdPerRequest ?? threshold;
 
 		const now = Date.now();
 		const cachedRecord = cache.get(index) || { timestamp: now };
 
 		if (method === 'get') {
 
-			if (now - cachedRecord.timestamp <= threshold) {
+			if (now - cachedRecord.timestamp <= effectiveThreshold) {
 
 				const responsePromise = cachedRecord.value;
 				if (responsePromise) {


### PR DESCRIPTION
## Summary

- Support per-request `threshold` override in `throttleAdapterEnhancer`, allowing users to customize throttle window per individual request (closes #98)
- Extend `AxiosRequestConfig` type via module augmentation with `threshold?: number`
- Add tests for per-request override and global fallback behavior

## Usage

```ts
// Override global threshold for a specific request
http.get('/endpoint', { threshold: 250 });

// Uses global threshold (default or from options)
http.get('/endpoint');
```

## Changes

- `src/throttleAdapterEnhancer.ts` — read `threshold` from request config, compute `effectiveThreshold` with fallback to global value
- `src/__tests__/test-throttleAdapterEnhancer.ts` — 2 new test cases