### PR TITLE
docs: rewrite README and add v3 to v4 migration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,64 +1,66 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-03-29 00:39:53 CST  
-**Commit:** 0ff55dc  
-**Branch:** feat/browser-friendly-cache
+**Generated:** 2026-03-30 23:42:10 CST  
+**Commit:** e2b0521  
+**Branch:** master
 
 ## OVERVIEW
-axios-extensions is a TypeScript library adding adapter enhancers for axios (cache, throttle, retry).
-It ships CJS (`lib`), ESM (`esm`), and browser UMD (`dist`) outputs from one source tree.
+axios-extensions is a TypeScript adapter-enhancer library for axios (cache/throttle/retry).
+Source-of-truth is `src/`; `lib`/`esm`/`dist` are generated outputs.
 
 ## STRUCTURE
 ```text
 ./
-├── src/                     # Source of truth: enhancers + utils + tests
-│   ├── __tests__/           # Enhancer-level tests
-│   └── utils/__tests__/     # Utility-level tests
-├── lib/                     # CJS build output (generated)
-├── esm/                     # ESM build output + .d.ts (generated)
-├── dist/                    # UMD outputs (generated)
-├── vite.config.ts           # Multi-mode build for cjs/esm/umd/umd-min
-├── vitest.config.ts         # Test + coverage configuration
-└── .github/workflows/       # CI + publish workflows
+├── src/                     # Runtime source, tests, utils
+│   ├── AGENTS.md            # Source-module guide
+│   └── utils/AGENTS.md      # Utility-layer local guide
+├── lib/                     # Generated CJS build
+├── esm/                     # Generated ESM build + d.ts
+├── dist/                    # Generated UMD build
+├── vite.config.ts           # Multi-mode library build
+├── vitest.config.ts         # Test and coverage config
+└── .github/workflows/       # CI + publish automation
 ```
 
 ## WHERE TO LOOK
 | Task | Location | Notes |
 |------|----------|-------|
-| Public exports | `src/index.ts` | Keep API surface stable for `main/module/types` fields |
-| Cache behavior | `src/cacheAdapterEnhancer.ts` | GET-only cache path, cache key from sorted URL |
-| Throttle behavior | `src/throttleAdapterEnhancer.ts` | Threshold window + in-flight dedupe |
-| Retry behavior | `src/retryAdapterEnhancer.ts` | Request-level override via `retryTimes` |
-| Cache abstraction | `src/Cache.ts`, `src/utils/isCacheLike.ts` | Supports `delete` and backward-compatible `del` |
-| URL normalization | `src/utils/buildSortedURL.ts` | Uses `axios.getUri` and sorted query pairs |
-| Test cases | `src/**/__tests__/*.ts` | Vitest + Sinon style |
-| Build/distribution | `package.json`, `vite.config.ts`, `tsconfig.types.json` | Preserve all three output families |
+| Public API surface | `src/index.ts` | Must stay aligned with package `main/module/types` |
+| Cache behavior | `src/cacheAdapterEnhancer.ts` | `cacheable` policy + key generation + `__fromCache` |
+| Throttle behavior | `src/throttleAdapterEnhancer.ts` | GET-only dedupe + per-request `threshold` |
+| Retry behavior | `src/retryAdapterEnhancer.ts` | global `times` + request `retryTimes` |
+| Adapter resolution | `src/utils/resolveAdapter.ts` | Handles axios v1 adapter forms |
+| Cache contract checks | `src/utils/isCacheLike.ts`, `src/utils/deleteCacheEntry.ts` | Supports `delete` and legacy `del` |
+| Build pipeline | `package.json`, `vite.config.ts`, `tsconfig.types.json` | cjs -> esm -> umd -> umd-min |
+| CI and release | `.github/workflows/*.yml`, `package.json#release` | release tag + GitHub publish split |
 
 ## CODE MAP
 | Symbol | Type | Location | Role |
 |--------|------|----------|------|
 | `cacheAdapterEnhancer` | function | `src/cacheAdapterEnhancer.ts` | Cache wrapper around resolved adapter |
-| `throttleAdapterEnhancer` | function | `src/throttleAdapterEnhancer.ts` | Time-window request throttle/dedupe |
-| `retryAdapterEnhancer` | function | `src/retryAdapterEnhancer.ts` | Retry failed requests |
-| `Cache` | class | `src/Cache.ts` | Default lightweight cache implementation |
-| `buildSortedURL` | function | `src/utils/buildSortedURL.ts` | Deterministic request key builder |
-| `isCacheLike` | function | `src/utils/isCacheLike.ts` | Runtime contract check for custom caches |
+| `throttleAdapterEnhancer` | function | `src/throttleAdapterEnhancer.ts` | Threshold-window request dedupe |
+| `retryAdapterEnhancer` | function | `src/retryAdapterEnhancer.ts` | Retry wrapper for failed requests |
+| `Cache` | class | `src/Cache.ts` | Default in-memory cache wrapper |
+| `resolveAdapter` | function | `src/utils/resolveAdapter.ts` | Normalize adapter input to function |
+| `buildSortedURL` | function | `src/utils/buildSortedURL.ts` | Stable key from sorted query pairs |
 
 ## CONVENTIONS (PROJECT-SPECIFIC)
-- Indentation uses tabs for code; JSON and selected config use spaces (`.editorconfig`).
-- ESLint allows `any` but enforces tab indentation and single quotes (`eslint.config.mjs`).
-- Tests run directly from source TypeScript via Vitest (`npm test`), not compiled test artifacts.
-- Build is mode-split Vite pipeline: `cjs -> esm -> umd -> umd-min`.
-- Package intentionally publishes `src` in addition to build outputs (`package.json#files`).
+- Tabs for code; spaces for JSON/config (`.editorconfig`).
+- ESLint allows `any`, enforces tabs + single quotes (`eslint.config.mjs`).
+- Tests run directly from source TS via Vitest (`vitest.config.ts`, `npm test`).
+- Package intentionally publishes `src` plus generated outputs (`package.json#files`).
+- UMD build keeps axios external and maps global `axios` (`vite.config.ts`).
 
 ## ANTI-PATTERNS (THIS PROJECT)
-- No explicit `DO NOT/NEVER` markers are defined in repository text.
-- Treat compatibility constraint as hard rule: axios `0.19.0` is unsupported (README note).
+- Do not edit `lib/`, `esm/`, or `dist/` directly; build regenerates them.
+- Do not target axios `<1.0.0` or Node `<18`.
+- Do not rely on axios `0.19.0` compatibility.
+- Do not bypass source entrypoints with imports from generated folders in source code.
 
 ## UNIQUE STYLES
-- Axios type augmentation is colocated in enhancer files via `declare module 'axios'`.
-- Cache APIs accept both modern `delete` and legacy `del` semantics.
-- Release flow is split: version/tag via `np --no-publish`; actual publish in GitHub Action.
+- Axios type augmentation is colocated inside enhancer files (`declare module 'axios'`).
+- Cache compatibility keeps both `delete` and `del` paths.
+- Release flow is two-step: version/tag (`np --no-publish`) then GitHub Action publish.
 
 ## COMMANDS
 ```bash
@@ -71,5 +73,5 @@ npm run release
 
 ## NOTES
 - Keep `main`, `module`, and `types` entrypoints aligned with generated outputs.
-- UMD builds must keep `axios` external and map global to `axios`.
-- Pre-push hook runs lint; local pushes fail if lint fails.
+- CI validates on Node 20.x and 22.x (`.github/workflows/ci.yml`).
+- Publish workflow triggers on `v4.*` tags (`publish-latest.yml`).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,95 +1,179 @@
-# Migration Guide
+# Migration Guide (v3 → v4)
 
-## `cacheAdapterEnhancer` options consolidation (v4.1)
+This document explains how to migrate from **axios-extensions v3** to the current **v4** API.
 
-v4.1 consolidates three cache options (`enabledByDefault`, `cacheFlag`, and the hardcoded `method === 'get'` check) into a single `cacheable` predicate.
+## TL;DR
 
-**Options removed:**
+1. Upgrade runtime dependencies:
+	- `node >= 18`
+	- `axios >= 1.0.0`
+2. Update cache enhancer configuration:
+	- replace `enabledByDefault` + `cacheFlag` with `cacheable`
+3. Review any custom non-GET caching strategy:
+	- ensure `keyGenerator` includes method/body semantics when needed
+
+## Breaking Changes
+
+### 1) Runtime baseline updated
+
+- **Node.js**: now `>= 18`
+- **axios**: now `>= 1.0.0`
+
+If your app is still on older Node or Axios major versions, upgrade those first.
+
+### 2) Cache options were consolidated
+
+In v3, cache behavior was controlled by multiple knobs (`enabledByDefault`, `cacheFlag`, plus method checks).
+
+In v4, this is unified into one predicate:
+
+```ts
+cacheable?: (config: AxiosRequestConfig) => boolean | ICacheLike<any>
+```
+
+Removed options:
+
 - `enabledByDefault`
 - `cacheFlag`
 
-**Option added:**
-- `cacheable: (config: AxiosRequestConfig) => boolean | ICacheLike`
+Unchanged defaults in v4:
 
-The default behavior is **unchanged** — GET requests are cached automatically, `cache: false` opts out per-request, and `cache: <CacheLike>` uses a custom store.
+- GET requests are cacheable by default
+- `cache: false` disables caching per request
+- `cache: <CacheLike>` uses a custom cache instance
 
-### Migration recipes
+### 3) `Cache` export is no longer `lru-cache`
 
-#### Default usage (no changes needed)
+In v3, `Cache` effectively came from `lru-cache`.
 
-```js
-// before
-cacheAdapterEnhancer(adapter)
+In v4, `Cache` is a library-owned wrapper built on `tiny-lru`.
 
-// after — identical, default cacheable handles everything
-cacheAdapterEnhancer(adapter)
+If your app relied on `lru-cache`-specific APIs, migrate to the cache-like contract used by enhancers:
+
+- `get(key)`
+- `set(key, value)`
+- `delete(key)` (or legacy `del(key)`)
+
+The exported `Cache` class also provides `clear()`, but enhancer integration does not require it.
+
+## Migration Recipes
+
+### A) No custom cache options (most users)
+
+No change needed:
+
+```ts
+// v3
+cacheAdapterEnhancer(adapter);
+
+// v4
+cacheAdapterEnhancer(adapter);
 ```
 
-#### `enabledByDefault: false`
+### B) `enabledByDefault: false` (opt-in caching)
 
-```js
-// before
-cacheAdapterEnhancer(adapter, { enabledByDefault: false })
+```ts
+// v3
+cacheAdapterEnhancer(adapter, { enabledByDefault: false });
 
-// after
+// v4
 cacheAdapterEnhancer(adapter, {
-  cacheable: (config) => config.cache ?? false,
-})
+	cacheable: config => config.method === 'get' ? (config.cache ?? false) : false,
+});
 ```
 
-#### `enabledByDefault: false` with `cacheFlag: 'useCache'`
+### C) `enabledByDefault: false` + custom `cacheFlag`
 
 ```js
-// before
-cacheAdapterEnhancer(adapter, { enabledByDefault: false, cacheFlag: 'useCache' })
+// v3
+cacheAdapterEnhancer(adapter, {
+	enabledByDefault: false,
+	cacheFlag: 'useCache',
+});
 // usage: http.get('/users', { useCache: true })
 
-// after
+// v4
 cacheAdapterEnhancer(adapter, {
-  cacheable: (config) => config.useCache ?? false,
-})
-// usage stays the same: http.get('/users', { useCache: true })
+	cacheable: config => config.method === 'get' ? (config.useCache ?? false) : false,
+});
+// usage unchanged: http.get('/users', { useCache: true })
 ```
 
-#### Custom `cacheFlag` with default enabled
+### D) Custom `cacheFlag` with default-enabled cache
 
 ```js
-// before
-cacheAdapterEnhancer(adapter, { cacheFlag: 'useCache' })
-// usage: http.get('/users', { useCache: false }) to opt out
+// v3
+cacheAdapterEnhancer(adapter, { cacheFlag: 'useCache' });
+// usage: http.get('/users', { useCache: false }) // opt out
 
-// after
+// v4
 cacheAdapterEnhancer(adapter, {
-  cacheable: (config) => {
-    if (config.useCache !== undefined) return config.useCache;
-    return config.method === 'get';
-  },
-})
+	cacheable: config => {
+		if (config.method !== 'get') return false;
+		if (config.useCache !== undefined) return config.useCache;
+		return true;
+	},
+});
 ```
 
-#### Cache POST requests (new)
+If you use TypeScript and custom flags like `useCache`, augment `AxiosRequestConfig` in your app:
 
-```js
-// before — not possible
+```ts
+import type { ICacheLike } from 'axios-extensions';
 
-// after
+declare module 'axios' {
+	interface AxiosRequestConfig {
+		useCache?: boolean | ICacheLike<any>;
+	}
+}
+```
+
+### E) Cache non-GET requests
+
+Use `cacheable` and a method-aware key:
+
+```ts
 cacheAdapterEnhancer(adapter, {
-  cacheable: (config) => config.method === 'get' || config.method === 'post',
-  keyGenerator: (config) => `${config.method}:${config.url}`,
-})
+	cacheable: config => config.method === 'get' || config.method === 'post',
+	keyGenerator: config => `${config.method}:${config.url}`,
+});
 ```
 
-### Why this change?
+> For body-sensitive POST caching, include request body in your key strategy.
 
-The previous API split "whether to cache" across three separate knobs. From first principles, caching has three concerns — **whether to cache**, **cache key**, and **cache store**. The new API maps options 1:1 to these concerns:
+## New/Important v4 Behaviors to Consider
 
-```
-Before (5 options):                After (3 options):
-  enabledByDefault  ─┐
-  cacheFlag         ─┼→  cacheable
-  method === 'get'  ─┘
-  keyGenerator      ───→  keyGenerator
-  defaultCache      ───→  defaultCache
+- `threshold` can be overridden per request in `throttleAdapterEnhancer`:
+
+```ts
+http.get('/users', { threshold: 3000 });
 ```
 
-The `cacheable` predicate receives the full `AxiosRequestConfig`, giving you complete control to implement any caching strategy — including POST caching, conditional caching based on URL patterns, or custom opt-in flags.
+- Retry still supports per-request `retryTimes` override:
+
+```ts
+http.get('/critical', { retryTimes: 3 });
+```
+
+- Cache hits add `response.__fromCache = true`.
+
+## Verification Checklist
+
+After migration, validate these points:
+
+- [ ] GET requests are cached as expected
+- [ ] `cache: false` correctly bypasses cache
+- [ ] Custom `cacheable` logic matches your previous v3 behavior
+- [ ] Non-GET caching (if enabled) uses a collision-safe key
+- [ ] Per-request `retryTimes` and `threshold` overrides behave as intended
+- [ ] Any direct `Cache` usage does not depend on `lru-cache`-specific methods
+
+## Why v4 made this change
+
+v3 spread cache policy across multiple options. v4 aligns the API to three explicit concerns:
+
+- **Whether to cache** → `cacheable`
+- **How to build cache key** → `keyGenerator`
+- **Where to store cache** → `defaultCache`
+
+That makes advanced policies (URL-based, method-based, opt-in, custom store) easier to express and reason about.

--- a/README.md
+++ b/README.md
@@ -1,259 +1,192 @@
 # axios-extensions
 
 [![npm version](https://img.shields.io/npm/v/axios-extensions.svg?style=flat-square)](https://www.npmjs.com/package/axios-extensions)
+[![build](https://img.shields.io/github/actions/workflow/status/kuitos/axios-extensions/ci.yml?branch=master&style=flat-square)](https://github.com/kuitos/axios-extensions/actions/workflows/ci.yml)
 [![coverage](https://img.shields.io/codecov/c/github/kuitos/axios-extensions.svg?style=flat-square)](https://codecov.io/gh/kuitos/axios-extensions)
 [![npm downloads](https://img.shields.io/npm/dt/axios-extensions.svg?style=flat-square)](https://www.npmjs.com/package/axios-extensions)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/kuitos/axios-extensions/ci.yml?branch=master&style=flat-square)](https://github.com/kuitos/axios-extensions/actions/workflows/ci.yml)
 
-A non-invasive, simple, reliable collection of axios extensions.
+Lightweight adapter enhancers for Axios:
 
-## Extension List
-*This README targets v4.x. If you are looking for older docs, see [v3.1.7](https://github.com/kuitos/axios-extensions/tree/v3.1.7) or [v2.0.3](https://github.com/kuitos/axios-extensions/tree/v2.0.3).* 
+- **`cacheAdapterEnhancer`**: request-level caching with custom cache strategy support
+- **`throttleAdapterEnhancer`**: dedupe/throttle GET calls inside a threshold window
+- **`retryAdapterEnhancer`**: retry failed requests with global or per-request overrides
 
-*v4.x requires Node.js >= 18 and axios >= 1.0.0.*
+> This README targets **v4.x**. Looking for older docs? See [v3.1.7](https://github.com/kuitos/axios-extensions/tree/v3.1.7).
+>
+> Migrating from v3? Read **[MIGRATION.md](./MIGRATION.md)**.
 
-*Not compatible with axios v0.19.0 due to a custom config bug. See https://github.com/axios/axios/pull/2207.*   
+## Requirements
 
-* [cacheAdapterEnhancer](#cacheadapterenhancer) makes requests cacheable
-* [throttleAdapterEnhancer](#throttleadapterenhancer) makes GET requests throttled automatically
-* [retryAdapterEnhancer](#retryadapterenhancer) retries failed requests a configurable number of times
+| Package | Supported version |
+| --- | --- |
+| Node.js | `>= 18` |
+| axios | `>= 1.0.0` |
 
-## Installing
+`axios v0.19.0` is not supported due to an Axios custom config issue: https://github.com/axios/axios/pull/2207
+
+## Installation
+
 ```bash
 npm i axios-extensions
 ```
+
 or
+
 ```bash
 yarn add axios-extensions
 ```
 
-or 
+Browser UMD build:
+
 ```html
-// exposed as window['axios-extensions']
+<!-- exposed as window['axios-extensions'] -->
 <script src="https://unpkg.com/axios-extensions/dist/axios-extensions.min.js"></script>
 ```
 
-## Usage
+## Quick Start
 
-```javascript
+```ts
 import axios from 'axios';
-import { cacheAdapterEnhancer, throttleAdapterEnhancer } from 'axios-extensions';
+import {
+	cacheAdapterEnhancer,
+	throttleAdapterEnhancer,
+	retryAdapterEnhancer,
+} from 'axios-extensions';
 
-// Enhance the original axios adapter with throttle and cache enhancers.
-const http = axios.create({
-	baseURL: '/',
-	headers: { 'Cache-Control': 'no-cache' },
-	adapter: throttleAdapterEnhancer(cacheAdapterEnhancer(axios.defaults.adapter))
+const adapter = retryAdapterEnhancer(
+	throttleAdapterEnhancer(
+		cacheAdapterEnhancer(axios.defaults.adapter!),
+		{ threshold: 1000 },
+	),
+	{ times: 2 },
+);
+
+export const http = axios.create({
+	baseURL: '/api',
+	adapter,
 });
-```
-
-### Enable Logging
-
-It is highly recommended to enable request logging in development environments (disabled by default).
-
-#### browser (webpack)
-```js
-new webpack.DefinePlugin({
-  'process.env.LOGGER_LEVEL': JSON.stringify('info')
-})
-```
-#### node
-```json
-// package.json
-"scripts": {
-	"start": "cross-env LOGGER_LEVEL=info node server.js"
-}
 ```
 
 ## API
 
-### cacheAdapterEnhancer
-
-> Makes axios cacheable
-
-```typescript
-cacheAdapterEnhancer(adapter: AxiosAdapter, options?: Options): AxiosAdapter
-```
-
-Where `adapter` is an axios adapter that follows the [axios adapter standard](https://github.com/axios/axios/blob/master/lib/adapters/README.md), and `options` is an optional object for configuring caching:
-
-| Param | Type | Default value | Description |
-| --- | --- | --- | --- |
-| cacheable | `(config: AxiosRequestConfig) => boolean \| ICacheLike` | See below | A predicate that decides whether a request should be cached. Return `true` to cache with `defaultCache`, return a `ICacheLike` instance to cache with that specific store, or return `false` to skip caching. |
-| keyGenerator | `(config: AxiosRequestConfig) => string` | `buildSortedURL(url, params)` | Generates the cache key for a request. |
-| defaultCache | `ICacheLike` | `new Cache({ ttl: 5min, max: 100 })` | The default cache store used when `cacheable` returns `true`. |
-
-The default `cacheable` implementation:
+### `cacheAdapterEnhancer`
 
 ```ts
-function defaultCacheable(config) {
-  // Per-request override via config.cache (boolean or ICacheLike instance)
-  if (config.cache !== undefined && config.cache !== null) return config.cache;
-  // Cache GET requests by default
-  return config.method === 'get';
-}
+cacheAdapterEnhancer(adapter: AxiosRequestConfig['adapter'], options?: {
+	cacheable?: (config: AxiosRequestConfig) => boolean | ICacheLike<any>;
+	keyGenerator?: (config: AxiosRequestConfig) => string;
+	defaultCache?: ICacheLike<AxiosPromise>;
+}): AxiosAdapter
 ```
 
-> **Migrating from `enabledByDefault`/`cacheFlag`?** See the [Migration Guide](./MIGRATION.md).
+Default behavior:
 
-`cacheAdapterEnhancer` enhances the given adapter and returns a new cacheable adapter back, so you can compose it with any other enhancers, e.g.  `throttleAdapterEnhancer`.
+- If `config.cache` is set, it is used as override
+- Otherwise GET requests are cached
+- Default cache store is `new Cache({ ttl: 5min, max: 100 })`
 
-#### basic usage
+Common request options (module-augmented on `AxiosRequestConfig`):
 
-```javascript
-import axios from 'axios';
-import { cacheAdapterEnhancer } from 'axios-extensions';
+- `cache?: boolean | ICacheLike<any>`
+- `forceUpdate?: boolean`
 
-const http = axios.create({
-	baseURL: '/',
-	headers: { 'Cache-Control': 'no-cache' },
-	// cache will be enabled by default for GET requests
-	adapter: cacheAdapterEnhancer(axios.defaults.adapter)
-});
-
-http.get('/users'); // make real http request
-http.get('/users'); // use the response from the cache of previous request, without real http request made
-http.get('/users', { cache: false }); // disable cache manually and make a real HTTP request
-```
-
-#### cache POST requests
-
-By providing a custom `cacheable` predicate, you can cache any HTTP method:
-
-```javascript
-const http = axios.create({
-	baseURL: '/',
-	headers: { 'Cache-Control': 'no-cache' },
-	adapter: cacheAdapterEnhancer(axios.defaults.adapter, {
-		cacheable: (config) => config.method === 'get' || config.method === 'post',
-		// include method in the cache key to avoid collisions between GET and POST
-		keyGenerator: (config) => `${config.method}:${config.url}`,
-	})
-});
-
-http.post('/query', { filter: 'active' }); // make real http request
-http.post('/query', { filter: 'active' }); // cache hit
-```
-
-#### opt-in caching (disabled by default)
-
-```javascript
-const http = axios.create({
-	baseURL: '/',
-	headers: { 'Cache-Control': 'no-cache' },
-	adapter: cacheAdapterEnhancer(axios.defaults.adapter, {
-		// only cache when explicitly opted in via config.cache
-		cacheable: (config) => config.cache ?? false,
-	})
-});
-
-http.get('/users'); // no cache, real HTTP request
-http.get('/users', { cache: true }); // cached (real HTTP request on first call)
-http.get('/users', { cache: true }); // cache hit
-```
-
-#### more advanced
-
-Besides configuring caching through `cacheAdapterEnhancer`, you can also configure advanced behavior per request.
-
-```js
-import axios from 'axios';
-import { cacheAdapterEnhancer, Cache } from 'axios-extensions';
-
-const http = axios.create({
-	baseURL: '/',
-	headers: { 'Cache-Control': 'no-cache' },
-	adapter: cacheAdapterEnhancer(axios.defaults.adapter)
-});
-
-// define a cache manually
-const cacheA = new Cache({ max: 100 });
-// or a cache-like instance
-const cacheB = { get() {/*...*/}, set() {/*...*/}, delete() {/*...*/} };
-
-// Two actual requests will be made because the caches are different.
-http.get('/users', { cache: cacheA });
-http.get('/users', { cache: cacheB });
-
-// An actual request is made and cached due to forceUpdate.
-http.get('/users', { cache: cacheA, forceUpdate: true });
-```
-
-*Note: If you are using typescript, do not forget to enable `"esModuleInterop": true` and `"allowSyntheticDefaultImports": true` for better development experience.*
-
-### throttleAdapterEnhancer
-
-> Throttle GET requests at most once per threshold milliseconds
+Example: enable cache for GET by default, but force a refresh per request:
 
 ```ts
-throttleAdapterEnhancer(adapter: AxiosAdapter, options?: Options): AxiosAdapter
+await http.get('/users', { forceUpdate: true });
 ```
 
-Where `adapter` is an axios adapter that follows the [axios adapter standard](https://github.com/axios/axios/blob/master/lib/adapters/README.md), and `options` is an optional object for configuring throttling:
-
-| Param     | Type |Default value               | Description                                                  |
-| --------- | ---- |--------------------------- | ------------------------------------------------------------ |
-| threshold | number |1000                        | The number of milliseconds to throttle request invocations to |
-| cache     | CacheLike |<pre>new Cache({ max: 10 })</pre> | CacheLike instance that will be used for storing throttled requests |
-
-We recommend using `throttleAdapterEnhancer` together with `cacheAdapterEnhancer` for maximum caching benefits.
-Note that POST and other methods besides GET are not affected. 
-
-```js
-throttleAdapterEnhancer(cacheAdapterEnhancer(axios.defaults.adapter))
-```
-
-Check [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/) to learn more details about throttle and how it differs from debounce.
-
-#### basic usage
-
-```js
-import axios from 'axios';
-import { throttleAdapterEnhancer } from 'axios-extensions';
-
-const http = axios.create({
-	baseURL: '/',
-	headers: { 'Cache-Control': 'no-cache' },
-	adapter: throttleAdapterEnhancer(axios.defaults.adapter, { threshold: 2 * 1000 })
-});
-
-http.get('/users'); // make real http request
-http.get('/users'); // responded from cache
-http.get('/users'); // responded from cache
-
-setTimeout(() => {
-	http.get('/users'); // after 2s, a real request is made again
-}, 2 * 1000);
-```
-
-### retryAdapterEnhancer
-
-> Retry failed requests a configurable number of times
+Example: opt-in cache only:
 
 ```ts
-retryAdapterEnhancer(adapter: AxiosAdapter, options?: Options): AxiosAdapter
+const adapter = cacheAdapterEnhancer(axios.defaults.adapter!, {
+	cacheable: config => config.cache ?? false,
+});
 ```
 
-Where `adapter` is an axios adapter that follows the [axios adapter standard](https://github.com/axios/axios/blob/master/lib/adapters/README.md), and `options` is an optional object for configuring retries:
-| Param            | Type | Default value                            | Description                                                  |
-| ---------------- | ---------------------------------------- | ------------------------------------------------------------ | ---- |
-| times | number                         | 2 | Set the retry times for failed request globally. |
-
-#### basic usage
+Example: cache GET + POST with a method-aware cache key:
 
 ```ts
-import axios from 'axios';
-import { retryAdapterEnhancer } from 'axios-extensions';
-
-const http = axios.create({
-	baseURL: '/',
-	headers: { 'Cache-Control': 'no-cache' },
-	adapter: retryAdapterEnhancer(axios.defaults.adapter)
+const adapter = cacheAdapterEnhancer(axios.defaults.adapter!, {
+	cacheable: config => config.method === 'get' || config.method === 'post',
+	keyGenerator: config => `${config.method}:${config.url}`,
 });
-
-// this request will retry two times if it fails
-http.get('/users');
-
-// you could also set the retry times for a special request
-http.get('/special', { retryTimes: 3 });
 ```
+
+`config.url` alone is only safe when query params/body do not change response semantics. Otherwise include `params` and (for non-GET) `data` in the key.
+
+### `throttleAdapterEnhancer`
+
+```ts
+throttleAdapterEnhancer(adapter: AxiosRequestConfig['adapter'], options?: {
+	threshold?: number;
+	cache?: ICacheLike<{ timestamp: number; value?: AxiosPromise }>;
+}): AxiosAdapter
+```
+
+Default behavior:
+
+- Only affects **GET** requests
+- Requests within `threshold` (default `1000ms`) reuse in-flight/previous promise
+- Non-GET requests pass through untouched
+
+Request-level override:
+
+- `threshold?: number` on `AxiosRequestConfig`
+
+```ts
+await http.get('/users', { threshold: 3000 });
+```
+
+### `retryAdapterEnhancer`
+
+```ts
+retryAdapterEnhancer(adapter: AxiosAdapter, options?: {
+	times?: number;
+}): AxiosAdapter
+```
+
+Default behavior:
+
+- Retries failed requests up to `times` (default `2`)
+- Per-request override via `retryTimes?: number`
+
+```ts
+await http.get('/critical-endpoint', { retryTimes: 3 });
+```
+
+## TypeScript Notes
+
+`axios-extensions` augments Axios request types for:
+
+- `cache`
+- `forceUpdate`
+- `threshold`
+- `retryTimes`
+
+When importing shared cache contracts in TypeScript, use type-only imports:
+
+```ts
+import type { ICacheLike } from 'axios-extensions';
+```
+
+If your project has strict interop settings, enabling these can improve import ergonomics:
+
+- `esModuleInterop: true`
+- `allowSyntheticDefaultImports: true`
+
+## Logging
+
+Set `process.env.LOGGER_LEVEL=info` to enable internal info logging in development.
+
+## Development
+
+```bash
+npm run lint
+npm test
+npm run build
+```
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 # axios-extensions
 
 [![npm version](https://img.shields.io/npm/v/axios-extensions.svg?style=flat-square)](https://www.npmjs.com/package/axios-extensions)
@@ -5,17 +7,59 @@
 [![coverage](https://img.shields.io/codecov/c/github/kuitos/axios-extensions.svg?style=flat-square)](https://codecov.io/gh/kuitos/axios-extensions)
 [![npm downloads](https://img.shields.io/npm/dt/axios-extensions.svg?style=flat-square)](https://www.npmjs.com/package/axios-extensions)
 
-Lightweight adapter enhancers for Axios:
+**Composable Axios adapter enhancers for cache, throttle, and retry.**
 
-- **`cacheAdapterEnhancer`**: request-level caching with custom cache strategy support
-- **`throttleAdapterEnhancer`**: dedupe/throttle GET calls inside a threshold window
-- **`retryAdapterEnhancer`**: retry failed requests with global or per-request overrides
+[Quick Start](#quick-start) • [API](#api) • [Migration](./MIGRATION.md) • [npm](https://www.npmjs.com/package/axios-extensions)
+
+</div>
+
+axios-extensions gives you production-friendly request behavior without replacing Axios itself.
 
 > This README targets **v4.x**. Looking for older docs? See [v3.1.7](https://github.com/kuitos/axios-extensions/tree/v3.1.7).
 >
 > Migrating from v3? Read **[MIGRATION.md](./MIGRATION.md)**.
 
-## Requirements
+## Table of Contents
+
+- [Why axios-extensions](#why-axios-extensions)
+- [Version & Compatibility](#version--compatibility)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [API](#api)
+  - [`cacheAdapterEnhancer`](#cacheadapterenhancer)
+  - [`throttleAdapterEnhancer`](#throttleadapterenhancer)
+  - [`retryAdapterEnhancer`](#retryadapterenhancer)
+- [TypeScript Notes](#typescript-notes)
+- [Logging](#logging)
+- [Development](#development)
+- [License](#license)
+
+## Highlights
+
+- ⚡ **Composable by design**: stack cache, throttle, and retry in one adapter pipeline.
+- 🧠 **Sensible defaults**: GET caching, GET-only throttling, and retry controls out of the box.
+- 🧩 **TypeScript-ready**: request config is module-augmented for feature flags and overrides.
+- 🪶 **Lightweight**: focused utilities with no framework lock-in.
+
+## Why axios-extensions
+
+| Enhancer | What it does | Typical use case |
+| --- | --- | --- |
+| `cacheAdapterEnhancer` | Request-level response caching | Avoid duplicate reads for the same resource |
+| `throttleAdapterEnhancer` | Dedupe/throttle GET requests inside a time window | Prevent burst requests during rapid UI interactions |
+| `retryAdapterEnhancer` | Retry failed requests with global/per-request overrides | Improve resilience on flaky networks |
+
+These enhancers are designed to be **composed together** on top of Axios adapters.
+
+### Pick the right enhancer
+
+| If you want to... | Use |
+| --- | --- |
+| Avoid duplicate reads and reuse response results | `cacheAdapterEnhancer` |
+| Collapse repeated GET requests in rapid bursts | `throttleAdapterEnhancer` |
+| Survive transient network/backend failures | `retryAdapterEnhancer` |
+
+## Version & Compatibility
 
 | Package | Supported version |
 | --- | --- |
@@ -30,8 +74,6 @@ Lightweight adapter enhancers for Axios:
 npm i axios-extensions
 ```
 
-or
-
 ```bash
 yarn add axios-extensions
 ```
@@ -44,6 +86,8 @@ Browser UMD build:
 ```
 
 ## Quick Start
+
+Compose all three enhancers in one adapter:
 
 ```ts
 import axios from 'axios';
@@ -67,12 +111,40 @@ export const http = axios.create({
 });
 ```
 
+Per-request overrides:
+
+```ts
+await http.get('/users', {
+	forceUpdate: true,
+	threshold: 3000,
+	retryTimes: 3,
+});
+```
+
+Common composition presets:
+
+```ts
+// 1) Cache only
+const cacheOnly = cacheAdapterEnhancer(axios.defaults.adapter!);
+
+// 2) Cache + throttle (great for list/search pages)
+const cacheAndThrottle = throttleAdapterEnhancer(
+	cacheAdapterEnhancer(axios.defaults.adapter!),
+	{ threshold: 1000 },
+);
+
+// 3) Full resilience pipeline
+const resilient = retryAdapterEnhancer(cacheAndThrottle, { times: 2 });
+```
+
 ## API
 
 ### `cacheAdapterEnhancer`
 
+When to use: cache requests (GET by default) and optionally customize cache strategy/key generation.
+
 ```ts
-cacheAdapterEnhancer(adapter: AxiosRequestConfig['adapter'], options?: {
+cacheAdapterEnhancer(adapter: NonNullable<AxiosRequestConfig['adapter']>, options?: {
 	cacheable?: (config: AxiosRequestConfig) => boolean | ICacheLike<any>;
 	keyGenerator?: (config: AxiosRequestConfig) => string;
 	defaultCache?: ICacheLike<AxiosPromise>;
@@ -83,14 +155,14 @@ Default behavior:
 
 - If `config.cache` is set, it is used as override
 - Otherwise GET requests are cached
-- Default cache store is `new Cache({ ttl: 5min, max: 100 })`
+- Default cache store is `new Cache({ ttl: 5 * 60 * 1000, max: 100 })`
 
 Common request options (module-augmented on `AxiosRequestConfig`):
 
 - `cache?: boolean | ICacheLike<any>`
 - `forceUpdate?: boolean`
 
-Example: enable cache for GET by default, but force a refresh per request:
+Example: enable cache for GET by default, but force refresh per request:
 
 ```ts
 await http.get('/users', { forceUpdate: true });
@@ -104,7 +176,7 @@ const adapter = cacheAdapterEnhancer(axios.defaults.adapter!, {
 });
 ```
 
-Example: cache GET + POST with a method-aware cache key:
+Example: cache GET + POST with a URL-only key (safe only when params/body do not affect response):
 
 ```ts
 const adapter = cacheAdapterEnhancer(axios.defaults.adapter!, {
@@ -117,8 +189,10 @@ const adapter = cacheAdapterEnhancer(axios.defaults.adapter!, {
 
 ### `throttleAdapterEnhancer`
 
+When to use: dedupe GET requests triggered repeatedly within a short interval.
+
 ```ts
-throttleAdapterEnhancer(adapter: AxiosRequestConfig['adapter'], options?: {
+throttleAdapterEnhancer(adapter: NonNullable<AxiosRequestConfig['adapter']>, options?: {
 	threshold?: number;
 	cache?: ICacheLike<{ timestamp: number; value?: AxiosPromise }>;
 }): AxiosAdapter
@@ -139,6 +213,8 @@ await http.get('/users', { threshold: 3000 });
 ```
 
 ### `retryAdapterEnhancer`
+
+When to use: retry transient failures without rewriting request logic.
 
 ```ts
 retryAdapterEnhancer(adapter: AxiosAdapter, options?: {
@@ -177,7 +253,7 @@ If your project has strict interop settings, enabling these can improve import e
 
 ## Logging
 
-Set `process.env.LOGGER_LEVEL=info` to enable internal info logging in development.
+Set `process.env.LOGGER_LEVEL=info` in Node-based development to enable internal info logging.
 
 ## Development
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -2,6 +2,7 @@
 
 **Scope:** `src/**`
 **Parent:** `../AGENTS.md`
+**Child Guide:** `./utils/AGENTS.md`
 
 ## OVERVIEW
 `src` contains all runtime behavior; generated directories must not be used as editing targets.
@@ -37,11 +38,13 @@ src/
 - Preserve `ICacheLike` compatibility path for both `.delete()` and `.del()`.
 - Keep helper utilities side-effect free; enhancer files own request-flow side effects.
 - Keep tests colocated under `__tests__` with `test-*.ts` naming.
+- Keep adapter handling through `utils/resolveAdapter.ts` for axios v1 compatibility.
 
 ## TESTING RULES (LOCAL)
 - Use Vitest assertions and Sinon spies (current suite style).
 - For enhancer behavior changes, update both success path and error path assertions.
 - For cache/throttle paths, assert adapter call counts in addition to response assertions.
+- Preserve browser-safety expectations (`process` can be undefined) in enhancer tests.
 
 ## ANTI-PATTERNS
 - Do not import from `lib/`, `esm/`, or `dist/` inside `src`.

--- a/src/utils/AGENTS.md
+++ b/src/utils/AGENTS.md
@@ -1,0 +1,42 @@
+# UTILS LAYER GUIDE
+
+**Scope:** `src/utils/**`
+**Parent:** `../AGENTS.md`
+
+## OVERVIEW
+Utility layer provides pure helpers for key building, adapter resolution, cache contract checks, and logging safety.
+
+## STRUCTURE
+```text
+src/utils/
+├── buildSortedURL.ts          # Stable request-key builder
+├── deleteCacheEntry.ts        # delete/del compatibility helper
+├── isCacheLike.ts             # Runtime guard + ICacheLike type
+├── resolveAdapter.ts          # Axios adapter normalization
+├── shouldLogInfo.ts           # process-safe logging gate
+└── __tests__/                 # Utility unit tests
+```
+
+## WHERE TO LOOK
+| Change Goal | Primary File | Secondary Impact |
+|-------------|--------------|------------------|
+| Cache key semantics | `buildSortedURL.ts` | cache/throttle enhancer behavior and tests |
+| Custom cache compatibility | `isCacheLike.ts`, `deleteCacheEntry.ts` | cache + throttle error cleanup paths |
+| Axios adapter input forms | `resolveAdapter.ts` | all enhancers accepting adapter name/config |
+| Browser-safe logging checks | `shouldLogInfo.ts` | all enhancer info-log branches |
+
+## CONVENTIONS (LOCAL)
+- Keep helpers side-effect free and synchronous where possible.
+- Keep compatibility behavior explicit: support both `delete` and legacy `del`.
+- `buildSortedURL` must stay deterministic for query ordering.
+- `resolveAdapter` must prefer function passthrough, fallback to `axios.getAdapter`.
+
+## TESTING RULES (LOCAL)
+- Utility tests belong in `src/utils/__tests__/` with `test-*.ts` naming.
+- For key-generation changes, test query ordering and existing query-string preservation.
+- For cache-like checks, keep object/function acceptance and null/primitive rejection coverage.
+
+## ANTI-PATTERNS
+- Do not add enhancer-level request-flow logic into utils.
+- Do not remove `del` fallback unless coordinated as a breaking change.
+- Do not make `shouldLogInfo` assume `process` exists in browser/UMD runtime.


### PR DESCRIPTION
## Summary
- fully rewrote README for v4 with clearer structure, compatibility requirements, quick-start, API reference, TypeScript notes, and migration callout
- rewrote MIGRATION.md for v3 -> v4 with explicit breaking changes, behavior-preserving migration recipes, and validation checklist
- aligned migration guidance with current source behavior (cacheable/keyGenerator, Cache export change, throttle/retry per-request options)

## Verification
- npm run lint
- npm test
- npm run build